### PR TITLE
Remove reset() from TransactionManager

### DIFF
--- a/dal-jdbc/src/main/java/org/unidal/dal/jdbc/query/msyql/MysqlReadHandler.java
+++ b/dal-jdbc/src/main/java/org/unidal/dal/jdbc/query/msyql/MysqlReadHandler.java
@@ -64,13 +64,11 @@ public class MysqlReadHandler extends MysqlBaseHandler implements ReadHandler {
       } catch (DataSourceException e) {
          t.setStatus(e.getClass().getSimpleName());
          Cat.logError(e);
-         m_transactionManager.reset();
 
          throw e;
       } catch (Throwable e) {
          t.setStatus(e.getClass().getSimpleName());
          Cat.logError(e);
-         m_transactionManager.reset();
 
          throw new DalException(String.format("Error when executing query(%s) failed, proto: %s, message: %s.",
                ctx.getSqlStatement(), proto, e), e);

--- a/dal-jdbc/src/main/java/org/unidal/dal/jdbc/query/msyql/MysqlWriteHandler.java
+++ b/dal-jdbc/src/main/java/org/unidal/dal/jdbc/query/msyql/MysqlWriteHandler.java
@@ -58,13 +58,11 @@ public class MysqlWriteHandler extends MysqlBaseHandler implements WriteHandler 
       } catch (DataSourceException e) {
          t.setStatus(e.getClass().getSimpleName());
          Cat.logError(e);
-         m_transactionManager.reset();
 
          throw e;
       } catch (Throwable e) {
          t.setStatus(e.getClass().getSimpleName());
          Cat.logError(e);
-         m_transactionManager.reset();
 
          throw new DalException(String.format("Error when executing update(%s) failed, proto: %s, message: %s.",
                ctx.getSqlStatement(), proto, e), e);
@@ -159,7 +157,6 @@ public class MysqlWriteHandler extends MysqlBaseHandler implements WriteHandler 
       } catch (DataSourceException e) {
          t.setStatus(e.getClass().getSimpleName());
          Cat.logError(e);
-         m_transactionManager.reset();
 
          throw e;
       } catch (Throwable e) {
@@ -176,7 +173,6 @@ public class MysqlWriteHandler extends MysqlBaseHandler implements WriteHandler 
 
          t.setStatus(e.getClass().getSimpleName());
          Cat.logError(e);
-         m_transactionManager.reset();
 
          throw new DalException(String.format("Error when executing batch update(%s) failed, proto: %s, message: %s.",
                ctx.getSqlStatement(), ctx.getProto(), e), e);

--- a/dal-jdbc/src/main/java/org/unidal/dal/jdbc/transaction/DefaultTransactionManager.java
+++ b/dal-jdbc/src/main/java/org/unidal/dal/jdbc/transaction/DefaultTransactionManager.java
@@ -145,24 +145,6 @@ public class DefaultTransactionManager implements TransactionManager, LogEnabled
       return trxInfo.isInTransaction();
    }
 
-   @Override
-   public void reset() {
-      TransactionInfo trxInfo = m_threadLocalData.get();
-
-      if (trxInfo != null) {
-         Connection conn = trxInfo.getConnection();
-
-         if (conn != null) {
-            try {
-               conn.close();
-            } catch (SQLException e) {
-               m_logger.error("Error when closing connection!", e);
-            }
-         }
-      }
-      m_threadLocalData.remove();
-   }
-
    public void rollbackTransaction() {
       TransactionInfo trxInfo = m_threadLocalData.get();
 
@@ -251,6 +233,7 @@ public class DefaultTransactionManager implements TransactionManager, LogEnabled
          m_connection = null;
          m_dataSourceName = null;
          m_inTransaction = false;
+         m_threadLocalData.remove();
       }
 
       public void setConnection(Connection connection) {

--- a/dal-jdbc/src/main/java/org/unidal/dal/jdbc/transaction/TransactionManager.java
+++ b/dal-jdbc/src/main/java/org/unidal/dal/jdbc/transaction/TransactionManager.java
@@ -13,8 +13,6 @@ public interface TransactionManager {
 
    public boolean isInTransaction();
 
-   public void reset();
-
    public void rollbackTransaction();
 
    public void startTransaction(String datasource);


### PR DESCRIPTION
It's a not perfect solution still. I know the 'reset' is used to release resource when exception happened. In current PR, I move the responsibility to the caller side. The caller will call commit/rollback finally. 