### PR TITLE
 Deprecated elements should have both the annotation and the Javadoc tag

### DIFF
--- a/foundation-service/src/main/java/org/unidal/lookup/annotation/Inject.java
+++ b/foundation-service/src/main/java/org/unidal/lookup/annotation/Inject.java
@@ -13,6 +13,10 @@ public @interface Inject {
 
    String[] value() default {};
 
+   /**
+    * @deprecated kept for backward compatibility 
+    * @return
+     */
    @Deprecated
    String instantiationStrategy() default "";
 

--- a/foundation-service/src/main/java/org/unidal/net/MessageDelegate.java
+++ b/foundation-service/src/main/java/org/unidal/net/MessageDelegate.java
@@ -4,6 +4,9 @@ import java.util.concurrent.TimeUnit;
 
 import org.jboss.netty.buffer.ChannelBuffer;
 
+/**
+ * @deprecated kept for backward compatibility 
+ */
 @Deprecated
 public interface MessageDelegate {
 	public ChannelBuffer nextMessage(long timeout, TimeUnit unit) throws InterruptedException;

--- a/foundation-service/src/main/java/org/unidal/net/MessageReceiver.java
+++ b/foundation-service/src/main/java/org/unidal/net/MessageReceiver.java
@@ -25,6 +25,9 @@ import org.jboss.netty.util.ThreadRenamingRunnable;
 import org.unidal.helper.Threads;
 import org.unidal.lookup.logger.LoggerFactory;
 
+/**
+ * @deprecated kept for backward compatibility 
+ */
 @Deprecated
 class MessageReceiver {
    private MessageDelegate m_delegate;

--- a/foundation-service/src/main/java/org/unidal/net/MessageSender.java
+++ b/foundation-service/src/main/java/org/unidal/net/MessageSender.java
@@ -24,6 +24,9 @@ import org.unidal.helper.Threads;
 import org.unidal.helper.Threads.Task;
 import org.unidal.lookup.logger.LoggerFactory;
 
+/**
+ * @deprecated kept for backward compatibility 
+ */
 @Deprecated
 class MessageSender implements Task {
    private MessageDelegate m_delegate;

--- a/foundation-service/src/main/java/org/unidal/net/Sockets.java
+++ b/foundation-service/src/main/java/org/unidal/net/Sockets.java
@@ -12,11 +12,19 @@ public class Sockets {
       return new Server();
    }
 
+   /**
+    * @deprecated kept for backward compatibility 
+    * @return
+     */
    @Deprecated
    public static SocketClient forClient() {
       return new SocketClient();
    }
 
+   /**
+    * @deprecated kept for backward compatibility 
+    * @return
+     */
    @Deprecated
    public static SocketServer forServer() {
       return new SocketServer();
@@ -115,6 +123,9 @@ public class Sockets {
       }
    }
 
+    /**
+     * @deprecated kept for backward compatibility 
+     */
    @Deprecated
    public static class SocketClient {
       private int m_port;
@@ -152,6 +163,9 @@ public class Sockets {
       }
    }
 
+   /**
+    * @deprecated kept for backward compatibility 
+    */
    @Deprecated
    public static class SocketServer {
       private String m_host;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:MissingDeprecatedCheck - “ Deprecated elements should have both the annotation and the Javadoc tag ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:MissingDeprecatedCheck
Please let me know if you have any questions.
Ayman Abdelghany.