### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/dal-jdbc/src/main/java/org/unidal/dal/jdbc/BizObjectHelper.java
+++ b/dal-jdbc/src/main/java/org/unidal/dal/jdbc/BizObjectHelper.java
@@ -5,6 +5,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class BizObjectHelper {
+   private BizObjectHelper() {
+   }
+
    @SuppressWarnings("unchecked")
    private static <T extends BizObject> Constructor<T> getBoConstructor(Class<T> boClass) {
       try {

--- a/foundation-service/src/main/java/org/unidal/converter/ConverterUtil.java
+++ b/foundation-service/src/main/java/org/unidal/converter/ConverterUtil.java
@@ -7,6 +7,9 @@ import java.util.Map;
 public class ConverterUtil {
    private static Map<Class<?>, Map<String, Method>> s_cachedSetMethodMap = new HashMap<Class<?>, Map<String, Method>>();
 
+   private ConverterUtil() {
+   }
+
    public static String getSetMethodName(String name) {
       StringBuilder sb = new StringBuilder(32);
       int len = name.length();

--- a/foundation-service/src/main/java/org/unidal/converter/TypeUtil.java
+++ b/foundation-service/src/main/java/org/unidal/converter/TypeUtil.java
@@ -21,6 +21,9 @@ public class TypeUtil {
       m_primitiveTypeMap.put(Double.TYPE, Double.class);
    }
 
+   private TypeUtil() {
+   }
+
    public static Type getComponentType(Type type) {
       Class<?> clazz;
 

--- a/foundation-service/src/main/java/org/unidal/lookup/util/ByteArrayUtils.java
+++ b/foundation-service/src/main/java/org/unidal/lookup/util/ByteArrayUtils.java
@@ -1,7 +1,10 @@
 package org.unidal.lookup.util;
 
 public class ByteArrayUtils {
-   public static byte[] trim(byte[] src) {
+    private ByteArrayUtils() {
+    }
+
+    public static byte[] trim(byte[] src) {
       int start = 0;
       int end = src.length;
       boolean trimed = false;

--- a/foundation-service/src/main/java/org/unidal/lookup/util/ReflectUtils.java
+++ b/foundation-service/src/main/java/org/unidal/lookup/util/ReflectUtils.java
@@ -5,6 +5,9 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 
 public class ReflectUtils {
+   private ReflectUtils() {
+   }
+
    @SuppressWarnings("unchecked")
    public static <T> T createInstance(Class<?> clazz) {
       try {

--- a/foundation-service/src/main/java/org/unidal/lookup/util/StringUtils.java
+++ b/foundation-service/src/main/java/org/unidal/lookup/util/StringUtils.java
@@ -3,6 +3,9 @@ package org.unidal.lookup.util;
 import java.util.Collection;
 
 public class StringUtils {
+   private StringUtils() {
+   }
+
    public static final boolean isEmpty(String str) {
       return str == null || str.length() == 0;
    }

--- a/type-converter/src/main/java/org/unidal/converter/ConverterUtil.java
+++ b/type-converter/src/main/java/org/unidal/converter/ConverterUtil.java
@@ -7,6 +7,9 @@ import java.util.Map;
 public class ConverterUtil {
    private static Map<Class<?>, Map<String, Method>> s_cachedSetMethodMap = new HashMap<Class<?>, Map<String, Method>>();
 
+   private ConverterUtil() {
+   }
+
    public static String getSetMethodName(String name) {
       StringBuilder sb = new StringBuilder(32);
       int len = name.length();

--- a/type-converter/src/main/java/org/unidal/converter/TypeUtil.java
+++ b/type-converter/src/main/java/org/unidal/converter/TypeUtil.java
@@ -21,6 +21,9 @@ public class TypeUtil {
       m_primitiveTypeMap.put(Double.TYPE, Double.class);
    }
 
+   private TypeUtil() {
+   }
+
    public static Type getComponentType(Type type) {
       Class<?> clazz;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.