### PR TITLE
"toString()" should never be called on a String object

### DIFF
--- a/foundation-service/src/main/java/org/unidal/helper/Objects.java
+++ b/foundation-service/src/main/java/org/unidal/helper/Objects.java
@@ -85,7 +85,7 @@ public class Objects {
          if (value == null) {
             m_sb.append("null");
          } else {
-            String str = value.toString();
+            String str = value;
 
             int len = str.length();
 
@@ -557,7 +557,7 @@ public class Objects {
          if (value == null) {
             m_sb.append("null");
          } else {
-            String str = value.toString();
+            String str = value;
 
             int len = str.length();
 

--- a/foundation-service/src/main/java/org/unidal/lookup/ContainerHolder.java
+++ b/foundation-service/src/main/java/org/unidal/lookup/ContainerHolder.java
@@ -35,9 +35,9 @@ public abstract class ContainerHolder implements Contextualizable {
 
    protected <T> T lookup(Class<T> role, String roleHint) throws LookupException {
       try {
-         return (T) m_container.lookup(role, roleHint == null ? "default" : roleHint.toString());
+         return (T) m_container.lookup(role, roleHint == null ? "default" : roleHint);
       } catch (ComponentLookupException e) {
-         String key = role.getName() + ":" + (roleHint == null ? "default" : roleHint.toString());
+         String key = role.getName() + ":" + (roleHint == null ? "default" : roleHint);
 
          throw new LookupException("Unable to lookup component(" + key + ").", e);
       }
@@ -51,7 +51,7 @@ public abstract class ContainerHolder implements Contextualizable {
       try {
          return ContainerLoader.lookupById(role, roleHint, id);
       } catch (ComponentLookupException e) {
-         String key = role.getName() + ":" + (roleHint == null ? "default" : roleHint.toString()) + "@" + id;
+         String key = role.getName() + ":" + (roleHint == null ? "default" : roleHint) + "@" + id;
 
          throw new LookupException("Unable to lookup component(" + key + ").", e);
       }

--- a/web-framework/src/main/java/org/unidal/web/AbstractContainerServlet.java
+++ b/web-framework/src/main/java/org/unidal/web/AbstractContainerServlet.java
@@ -69,7 +69,7 @@ public abstract class AbstractContainerServlet extends HttpServlet {
 
 	protected <T> T lookup(Class<T> role, String roleHint) throws LookupException {
 		try {
-			return (T) m_container.lookup(role, roleHint == null ? "default" : roleHint.toString());
+			return (T) m_container.lookup(role, roleHint == null ? "default" : roleHint);
 		} catch (ComponentLookupException e) {
 			throw new LookupException("Component(" + role.getName() + ") lookup failure. details: " + e.getMessage(), e);
 		}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1858 - “"toString()" should never be called on a String object”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1858
Please let me know if you have any questions.
Ayman Abdelghany.